### PR TITLE
feat: use latest node version as default

### DIFF
--- a/create-release/action.yml
+++ b/create-release/action.yml
@@ -16,7 +16,7 @@ inputs:
   node-version:
     description: "The node version to use."
     required: false
-    default: "18.12.x"
+    default: "latest"
   user-token:
     description: "Token to be used to checkout the sources."
     required: true


### PR DESCRIPTION
Should fix this: https://github.com/kraussmaffei/common-monitoring/actions/runs/6231885638/job/16918450950?pr=48